### PR TITLE
Generalize entrypoint of the image

### DIFF
--- a/docker.entrypoint.sh
+++ b/docker.entrypoint.sh
@@ -7,4 +7,4 @@ then
     neuro config switch-cluster "$NEURO_CLUSTER" 1>/dev/null
 fi
 
-exec neuro "$@"
+exec "$@"


### PR DESCRIPTION
Note: for now, we only change the image's entrypoint without fixing the code of neuro-extras. Then: we do an alpha-release, publish the docker image, and then we can fix the code.