### PR TITLE
Make release instructions more concise

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,16 +1,15 @@
 # Versioning
 
-The project uses release versioning a format YY.MM.DD. For instance, when releasing a version on Sep 15, 2021, it would be versionsed as 21.9.15. Note there's no leading zeroes in day and month number.
+The project uses release versioning a format `YY.MM.DD`. For instance, when releasing a version on Sep 15, 2021, it would be versionsed as `21.9.15` (no zero before `9`). Note: you'll be setting version in format `vYY.MM.DD`, prefix `v` will be cut automatically.
+
 
 # Release process
-The release process is logically split onto two steps: firstly we release docker image with an updated code,
-  afterwards we release an updated `neuro-extras` Python package to PyPi.
 
-*Note*: Start with step 1 if the docker image should be updated. Otherwise - start with step 5.
+*Note*: Start with part 1 if the docker image should be updated. Otherwise - go directly to part 2.
 
 Suppose, today is October 14, 2020, and we want to update both neuro-extras pip package and docker image.
 
-- Make sure all tests are green in `master` branch.
+0. Make sure all tests are green in `master` branch.
 
 ## Part 1: alpha-release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,17 +6,42 @@ The project uses release versioning a format YY.MM.DD. For instance, when releas
 The release process is logically split onto two steps: firstly we release docker image with an updated code,
   afterwards we release an updated `neuro-extras` Python package to PyPi.
 
-##### Note: Start with step 1 if the docker image should be updated. Otherwise - start with step 5.
+*Note*: Start with step 1 if the docker image should be updated. Otherwise - start with step 5.
 
-1. Make sure all tests are green in master branch.
-2. Bump version in `neuro_extras/__init__.py` to an `alpha version` (postfixed with aN where N is a number), commit & push.
-3. Submit pre-release on GitHub with a corresponding alpha. 
-It will trigger CI/CD, test and publish a new docker image and alpha release in PyPi (docker's `neuromation/neuro-extras:latest` won't be an alpha image and `pip install -U neuro-extras` won't upgrade on an alpha version).
-If all is OK, you could move to the next step, where you publish `neuro-extras` Python package to PyPi, which will use the previously published docker image. 
-4. Bump version of docker image in `neuro_extras/main.py` to the previously published `alpha version`.
-5. Bump version in `neuro_extras/__init__.py` to the `normal version`.
-6. Run `make changelog-draft` and verify changelog looks valid
-7. Run `make changelog` - this will delete changelog items from `CHANGELOG.d` and create a commit with updated CHANGELOG.md file
-8. Commit proposed changelog changes & push to GitHub.
-9. Create a release on GitHub. Make sure to prefix your version number with `v`, i.e. for version 21.9.15 you would name your release `v21.9.15`
-10. Wait for corresponding GitHub Action to complete.
+Suppose, today is October 14, 2020, and we want to update both neuro-extras pip package and docker image.
+
+- Make sure all tests are green in `master` branch.
+
+## Part 1: alpha-release
+
+1. Bump alpha version in the code.
+    - `git checkout master`;
+    - update `neuro_extras/__init__.py`: `__version__ = "v20.10.15a1"` (note postfix `a1`);
+    - `git commit -m "Update __init__.py version to v20.10.15a1"` and `push` directly to `origin/master`;
+    - wait for green build in [Actions](https://github.com/neuro-inc/neuro-extras/actions);
+
+2. Submit a pre-release on GitHub.
+    - go to [Releases](https://github.com/neuro-inc/neuro-extras/releases/), `Draft a new release`, tag: `v20.10.15a1` (note: postfix `a1`);
+    - wait for green build in [Actions](https://github.com/neuro-inc/neuro-extras/actions);
+    - verify that docker image was updated on [DockerHub](https://hub.docker.com/r/neuromation/neuro-extras/tags);
+    - Note: `pip install -U neuro-extras` won't upgrade as it's an alpha release;
+
+## Part 2: full-release
+
+3. Use the newly updated docker image inside the code.
+    - `git checkout master`;
+    - set the new alpha version `v20.10.15a1` to variable `NEURO_EXTRAS_IMAGE_TAG` in `neuro_extras/main.py`;
+    - `git commit -m "Use image version to v20.10.15a1"` and `push` directly to `origin/master`;
+
+4. Bump non-alpha version in the code.
+    - `git checkout master`;
+    - update `neuro_extras/__init__.py`: `__version__ = "v20.10.15"` (note: no postfixes);
+    - run `make changelog-draft` and verify changelog looks valid;
+    - run `make changelog` - this will delete changelog items from `CHANGELOG.d`;
+    - `git add . && git commit -m "Release version v20.10.15"` and `push` directly to `origin/master`;
+    - wait for green build in [Actions](https://github.com/neuro-inc/neuro-extras/actions);
+
+5. Submit a release on GitHub.
+    - go to [Releases](https://github.com/neuro-inc/neuro-extras/releases/), `Draft a new release`, tag: `v20.10.15` (note: no postfixes);
+    - wait for green build in [Actions](https://github.com/neuro-inc/neuro-extras/actions);
+    - verify that `pip install -U neuro-extras` does install `neuro-extras==20.10.15`

--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -118,7 +118,7 @@ def init_aliases() -> None:
     logger.info(f"Added aliases to {toml_path}")
 
 
-NEURO_EXTRAS_IMAGE_TAG = "v20.10.15a1"
+NEURO_EXTRAS_IMAGE_TAG = "v20.9.30a7"
 NEURO_EXTRAS_IMAGE = f"neuromation/neuro-extras:{NEURO_EXTRAS_IMAGE_TAG}"
 
 

--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -118,7 +118,7 @@ def init_aliases() -> None:
     logger.info(f"Added aliases to {toml_path}")
 
 
-NEURO_EXTRAS_IMAGE_TAG = "v20.9.30a7"
+NEURO_EXTRAS_IMAGE_TAG = "v20.10.15a1"
 NEURO_EXTRAS_IMAGE = f"neuromation/neuro-extras:{NEURO_EXTRAS_IMAGE_TAG}"
 
 


### PR DESCRIPTION
1. Separate with bullets
2. add links
3. specify commit messages for uniformity