### PR TITLE
Rework release process: test release version in real

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -159,7 +159,7 @@ jobs:
         os: [ubuntu, macos, windows]
       fail-fast: false
     runs-on: ${{ matrix.os }}-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       NEURO_STAGING_URL: ${{ secrets.NEURO_STAGING_URL }}
       NEURO_TOKEN: ${{ secrets.NEURO_TOKEN }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,10 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
   release:
     types: [ published ]
 
@@ -155,7 +151,7 @@ jobs:
 
   test:
     name: Run e2e tests against release image
-    needs: [pretest]
+    needs: [dockerhub_deploy]
     if: github.event_name == 'release'
     strategy:
       matrix:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -93,7 +93,7 @@ jobs:
           python-version: "3.7"
       - name: Install dependencies
         run: |
-          python -m pip install twine wheel
+          python -m pip install
           make setup
       - name: Wait until package becomes available on PyPI
         timeout-minutes: 5

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -159,7 +159,7 @@ jobs:
         os: [ubuntu, macos, windows]
       fail-fast: false
     runs-on: ${{ matrix.os }}-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       NEURO_STAGING_URL: ${{ secrets.NEURO_STAGING_URL }}
       NEURO_TOKEN: ${{ secrets.NEURO_TOKEN }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,225 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  release:
+    types: [ published ]
+
+jobs:
+
+  info:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout commit
+        uses: actions/checkout@v2
+      - name: Setup Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - name: Cache PyPI
+        uses: actions/cache@v2
+        with:
+          key: pip-lint-${{ hashFiles('requirements/*.txt') }}
+          path: ~/.cache/pip
+          restore-keys: |
+              pip-lint-
+      - name: Install dependencies
+        run: |
+          python -m pip
+          make setup
+      - name: Save the package version
+        id: version
+        run: |
+          echo "::set-output name=version::$(python setup.py --version)"
+      - name: Show version
+        run: |
+            echo ${{ steps.version.outputs.version }}
+
+  devpi_deploy:
+    name: Release package
+    runs-on: ubuntu-latest
+    needs: [info]
+    if: github.event_name == 'release'
+    steps:
+      - name: Checkout commit
+        uses: actions/checkout@v2
+      - name: Sanity check for tag and version
+        run: |
+          export VERSION=${{ needs.info.outputs.version }}
+          if [ "${{ github.ref }}" != "refs/tags/$VERSION" ]
+          then
+            echo "Git tag '${{ github.ref }}' differs from hard-coded package version '$VERSION'"
+            exit 1
+          else
+            echo "OK, git tag matches hard-coded package version: '$VERSION'"
+          fi
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - name: Install dependencies
+        run: |
+          python -m pip install twine wheel
+          make setup
+      - name: Make dists
+        run: |
+          python setup.py sdist bdist_wheel
+      - name: PyPI upload
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          twine upload dist/*
+
+  dockerhub_deploy:
+    name: Release image if needed
+    runs-on: ubuntu-latest
+    needs: [info, devpi_deploy]
+    if: github.event_name == 'release'
+    env:
+      DOCKER_SERVER: docker.io
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    steps:
+      - name: Checkout commit
+        uses: actions/checkout@v2
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - name: Install dependencies
+        run: |
+          python -m pip install twine wheel
+          make setup
+      - name: Wait until package becomes available on PyPI
+        timeout-minutes: 5
+        run: |
+          PYPIVERSION=$(python setup.py --version)
+          PYPIPACKAGE=neuro-extras==$PYPIVERSION
+          until python -m pip install $PYPIPACKAGE
+          do
+              echo "Waiting for the pypi package $PYPIPACKAGE ..."
+              sleep 1
+          done
+      - name: Build release image
+        run: |
+          export PACKAGE="neuro-extras==${{ needs.info.outputs.version }}"
+          docker build -t neuromation/neuro-extras:latest \
+            --build-arg NEURO_EXTRAS_PACKAGE=$PACKAGE .
+      - name: Push release release image
+        id: push
+        run: |
+          export IMAGE=neuromation/neuro-extras
+          export TAG=${{ needs.info.outputs.version }}
+
+          echo "::set-output name=image::$IMAGE"
+          echo "::set-output name=tag::$TAG"
+
+          docker login $DOCKER_SERVER --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+          docker tag neuromation/neuro-extras:latest neuromation/neuro-extras:$TAG
+          docker push neuromation/neuro-extras:$TAG
+          # Push latest if it's not an alpha release:
+          #   not alpha: TAG="20.9.29"
+          #       alpha: TAG="20.9.29a1"
+          if [[ ! "$TAG" =~ ^.*a[0-9]*$ ]]; then
+            docker push neuromation/neuro-extras:latest
+          fi
+      - name: Wait until image becomes available on DockerHub
+        timeout-minutes: 10
+        run: |
+          export IMAGE=${{ steps.push.outputs.image }}
+          export TAG=${{ steps.push.outputs.tag }}
+
+          docker_tag_exists () {
+              CT="Content-Type: application/json"
+              U=$DOCKER_USERNAME
+              P=$DOCKER_PASSWORD
+              URL=https://hub.docker.com
+              TOKEN=$(curl -s -H "$CT" -X POST -d '{"username": "'$U'", "password": "'$P'"}' $URL/v2/users/login/ | jq -r .token)
+              curl --silent -f --head -lL $URL/v2/repositories/$1/tags/$2/ > /dev/null
+          }
+
+          until docker_tag_exists $IMAGE $TAG
+          do
+              echo "Waiting for the dockerhub image $IMAGE:$TAG ..."
+              sleep 1
+          done
+
+  test:
+    name: Run e2e tests against release image
+    needs: [pretest]
+    if: github.event_name == 'release'
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7]
+        os: [ubuntu, macos, windows]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}-latest
+    timeout-minutes: 10
+    env:
+      NEURO_STAGING_URL: ${{ secrets.NEURO_STAGING_URL }}
+      NEURO_TOKEN: ${{ secrets.NEURO_TOKEN }}
+      NEURO_CLUSTER: neuro-compute
+      DOCKER_SERVER: docker.io
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    steps:
+      - name: Checkout commit
+        uses: actions/checkout@v2
+      - name: Install python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"    # - name: dir
+      - name: Cache PyPI
+        uses: actions/cache@v2
+        with:
+          key: pip-ci-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py', 'requirements/*.txt') }}
+          path: ${{ steps.pip-cache.outputs.dir }}
+          restore-keys: |
+              pip-ci-${{ runner.os }}-${{ matrix.python-version }}-
+      - name: Install libraries on Linux
+        if: matrix.os == 'ubuntu'
+        shell: bash
+        run: |
+          curl https://rclone.org/install.sh | sudo bash
+      - name: Install libraries on macOS
+        if: matrix.os == 'macos'
+        shell: bash
+        run: |
+          curl https://rclone.org/install.sh | sudo bash
+      - name: Install python dependencies
+        run: |
+          make setup
+      - name: Configure neuro
+        run: |
+          neuro config login-with-token ${{ env.NEURO_TOKEN }} ${{ env.NEURO_STAGING_URL }}
+          neuro config switch-cluster ${{ env.NEURO_CLUSTER }}
+          neuro config show
+      - name: Configure GCP access
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.E2E_COOKIECUTTER_GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.E2E_COOKIECUTTER_GCP_SA_KEY }}
+          export_default_credentials: true
+      - name: Configure AWS access
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.E2E_COOKIECUTTER_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.E2E_COOKIECUTTER_AWS_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Run e2e tests
+        run: |
+            unset NEURO_EXTRAS_IMAGE  # clear this env var to test it in real
+            make test_e2e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,9 +197,9 @@ jobs:
       - name: Sanity check for tag and version
         run: |
           export VERSION=${{ needs.lint.outputs.version }}
-          if [ "${{ github.ref }}" != "refs/tags/v$VERSION" ]
+          if [ "${{ github.ref }}" != "refs/tags/$VERSION" ]
           then
-            echo "Git tag '${{ github.ref }}' != hard-coded package version '$VERSION'"
+            echo "Git tag '${{ github.ref }}' differs from hard-coded package version '$VERSION'"
             exit 1
           else
             echo "OK, git tag matches hard-coded package version: '$VERSION'"
@@ -260,14 +260,14 @@ jobs:
             --build-arg NEURO_EXTRAS_PACKAGE=$PACKAGE .
       - name: Push release release image
         run: |
-          export TAG=v${{ needs.lint.outputs.version }}
+          export TAG="${{ needs.lint.outputs.version }}"
 
           docker login $DOCKER_SERVER --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
           docker tag neuromation/neuro-extras:latest neuromation/neuro-extras:$TAG
           docker push neuromation/neuro-extras:$TAG
           # Push latest if it's not an alpha release:
-          #   not alpha: TAG="v20.9.29"
-          #   alpha: TAG="v20.9.29a1"
+          #   not alpha: TAG="20.9.29"
+          #       alpha: TAG="20.9.29a1"
           if [[ ! "$TAG" =~ ^.*a[0-9]*$ ]]; then
             docker push neuromation/neuro-extras:latest
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,6 @@ jobs:
     name: Linter
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    outputs:
-      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout commit
         uses: actions/checkout@v2
@@ -32,18 +30,11 @@ jobs:
               pip-lint-
       - name: Install dependencies
         run: |
-          python -m pip install twine wheel
+          python -m pip install
           make setup
       - name: Run linters
         run: |
           make lint
-      - name: Save the package version
-        id: version
-        run: |
-          echo "::set-output name=version::$(python setup.py --version)"
-      - name: Show version
-        run: |
-            echo ${{ steps.version.outputs.version }}
 
   pretest:
     name: Prepare for e2e tests
@@ -184,90 +175,3 @@ jobs:
 #      - name: Delete test image
 #        run: |
 #          neuro image delete $NEURO_EXTRAS_IMAGE
-
-
-  devpi_deploy:
-    name: Release package if needed
-    runs-on: ubuntu-latest
-    needs: [lint, test]
-    if: github.event_name == 'release'
-    steps:
-      - name: Checkout commit
-        uses: actions/checkout@v2
-      - name: Sanity check for tag and version
-        run: |
-          export VERSION=${{ needs.lint.outputs.version }}
-          if [ "${{ github.ref }}" != "refs/tags/$VERSION" ]
-          then
-            echo "Git tag '${{ github.ref }}' differs from hard-coded package version '$VERSION'"
-            exit 1
-          else
-            echo "OK, git tag matches hard-coded package version: '$VERSION'"
-          fi
-      - name: Install python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.7"
-      - name: Install dependencies
-        run: |
-          python -m pip install twine wheel
-          make setup
-      - name: Make dists
-        run: |
-          python setup.py sdist bdist_wheel
-      - name: PyPI upload
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          twine upload dist/*
-
-  dockerhub_deploy:
-    name: Release image if needed
-    runs-on: ubuntu-latest
-    needs: [lint, devpi_deploy]
-    if: github.event_name == 'release'
-    env:
-      DOCKER_SERVER: docker.io
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-    steps:
-      - name: Checkout commit
-        uses: actions/checkout@v2
-      - name: Install python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.7"
-      - name: Install dependencies
-        run: |
-          python -m pip install twine wheel
-          make setup
-      - name: Wait until package becomes available on PyPI
-        timeout-minutes: 5
-        run: |
-          PYPIVERSION=$(python setup.py --version)
-          PYPIPACKAGE=neuro-extras==$PYPIVERSION
-          until python -m pip install $PYPIPACKAGE
-          do
-              echo "Waiting for the pypi package $PYPIPACKAGE..."
-              sleep 1
-          done
-      - name: Build release image
-        run: |
-          export PACKAGE="neuro-extras==${{ needs.lint.outputs.version }}"
-
-          docker build -t neuromation/neuro-extras:latest \
-            --build-arg NEURO_EXTRAS_PACKAGE=$PACKAGE .
-      - name: Push release release image
-        run: |
-          export TAG="${{ needs.lint.outputs.version }}"
-
-          docker login $DOCKER_SERVER --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-          docker tag neuromation/neuro-extras:latest neuromation/neuro-extras:$TAG
-          docker push neuromation/neuro-extras:$TAG
-          # Push latest if it's not an alpha release:
-          #   not alpha: TAG="20.9.29"
-          #       alpha: TAG="20.9.29a1"
-          if [[ ! "$TAG" =~ ^.*a[0-9]*$ ]]; then
-            docker push neuromation/neuro-extras:latest
-          fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
         os: [ubuntu, macos, windows]
       fail-fast: false
     runs-on: ${{ matrix.os }}-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       NEURO_STAGING_URL: ${{ secrets.NEURO_STAGING_URL }}
       NEURO_TOKEN: ${{ secrets.NEURO_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
 
   lint:
     name: Linter
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -38,6 +39,7 @@ jobs:
 
   pretest:
     name: Prepare for e2e tests
+    if: github.event_name == 'release'
     needs: [lint]
     runs-on: ubuntu-latest
     env:
@@ -79,6 +81,7 @@ jobs:
 
   test:
     name: Run e2e tests
+    if: github.event_name == 'release'
     needs: [pretest]
     strategy:
       matrix:
@@ -153,6 +156,7 @@ jobs:
 # TODO (yartem) Uncomment this step when neuro-image-delete is implemented
 #  posttest:
 #    name: Cleanup after successful e2e tests
+#    if: github.event_name == 'release'
 #    needs: [test]
 #    runs-on: ubuntu-latest
 #    env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
         os: [ubuntu, macos, windows]
       fail-fast: false
     runs-on: ${{ matrix.os }}-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       NEURO_STAGING_URL: ${{ secrets.NEURO_STAGING_URL }}
       NEURO_TOKEN: ${{ secrets.NEURO_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,14 +5,11 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  release:
-    types: [ published ]
 
 jobs:
 
   lint:
     name: Linter
-    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -39,7 +36,6 @@ jobs:
 
   pretest:
     name: Prepare for e2e tests
-    if: github.event_name == 'release'
     needs: [lint]
     runs-on: ubuntu-latest
     env:
@@ -81,7 +77,6 @@ jobs:
 
   test:
     name: Run e2e tests
-    if: github.event_name == 'release'
     needs: [pretest]
     strategy:
       matrix:
@@ -156,7 +151,6 @@ jobs:
 # TODO (yartem) Uncomment this step when neuro-image-delete is implemented
 #  posttest:
 #    name: Cleanup after successful e2e tests
-#    if: github.event_name == 'release'
 #    needs: [test]
 #    runs-on: ubuntu-latest
 #    env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
               pip-lint-
       - name: Install dependencies
         run: |
-          python -m pip install
+          python -m pip install pip
           make setup
       - name: Run linters
         run: |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,13 +5,11 @@ The project uses release versioning a format `YY.MM.DD` (both for pip packages a
 
 # Release process
 
-*Note*: Start with part 1 if the docker image should be updated. Otherwise - go directly to part 2.
-
 Suppose, today is October 15, 2020, and we want to update both neuro-extras pip package and docker image.
 
 0. Make sure all tests are green in `master` branch.
 
-1. Use the newly updated docker image inside the code.
+1. Bump code version directly to `master`.
     - `git checkout master`;
     - update `neuro_extras/version.py`: set `__version__ = "20.10.15"`;
     - run `make changelog-draft` and verify changelog looks valid;

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,6 @@ Suppose, today is October 15, 2020, and we want to update both neuro-extras pip 
 
 1. Use the newly updated docker image inside the code.
     - `git checkout master`;
-    - `git checkout master`;
     - update `neuro_extras/version.py`: set `__version__ = "20.10.15"`;
     - run `make changelog-draft` and verify changelog looks valid;
     - run `make changelog` - this will delete changelog items from `CHANGELOG.d`;

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@ Suppose, today is October 15, 2020, and we want to update both neuro-extras pip 
     - wait for green build in [Actions](https://github.com/neuro-inc/neuro-extras/actions);
 
 2. Submit a release on GitHub.
-    - go to [Releases](https://github.com/neuro-inc/neuro-extras/releases/), `Draft a new release`, tag: `v20.10.15` (note: no postfixes);
+    - go to [Releases](https://github.com/neuro-inc/neuro-extras/releases/), `Draft a new release`, tag: `20.10.15` (note: no postfixes);
     - wait for green build in [Actions](https://github.com/neuro-inc/neuro-extras/actions);
     - if the build failed, fix the errors and repeat from step 1. with version postfix: `20.10.15-1`.
     - verify that `pip install -U neuro-extras` does install `neuro-extras==20.10.15`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Versioning
 
-The project uses release versioning a format `YY.MM.DD`. For instance, when releasing a version on Sep 15, 2021, it would be versionsed as `21.9.15` (no zero before `9`). Note: you'll be setting version in format `vYY.MM.DD`, prefix `v` will be cut automatically.
+The project uses release versioning a format `YY.MM.DD` (both for pip packages and image tags). For instance, when releasing a version on Sep 15, 2021, it would be versionsed as `21.9.15` (no zero before `9`).
 
 
 # Release process
@@ -11,36 +11,24 @@ Suppose, today is October 15, 2020, and we want to update both neuro-extras pip 
 
 0. Make sure all tests are green in `master` branch.
 
-## Part 1: alpha-release
-
-1. Bump alpha version in the code.
+1. Use the newly updated docker image inside the code.
     - `git checkout master`;
-    - update `neuro_extras/version.py`: `__version__ = "v20.10.15a1"` (note postfix `a1`);
-    - `git add . && git commit -m "Update code version to v20.10.15a1"` and `push` directly to `origin/master`;
-    - wait for green build in [Actions](https://github.com/neuro-inc/neuro-extras/actions);
-
-2. Submit a pre-release on GitHub.
-    - go to [Releases](https://github.com/neuro-inc/neuro-extras/releases/), `Draft a new release`, tag: `v20.10.15a1` (note: postfix `a1`);
-    - wait for green build in [Actions](https://github.com/neuro-inc/neuro-extras/actions);
-    - verify that docker image was updated on [DockerHub](https://hub.docker.com/r/neuromation/neuro-extras/tags);
-    - Note: `pip install -U neuro-extras` won't upgrade as it's an alpha release;
-
-## Part 2: full-release
-
-3. Use the newly updated docker image inside the code.
     - `git checkout master`;
-    - set the new alpha version `v20.10.15a1` to variable `NEURO_EXTRAS_IMAGE_TAG` in `neuro_extras/main.py`;
-    - `git commit -m "Use image version to v20.10.15a1"` and `push` directly to `origin/master`;
-
-4. Bump non-alpha version in the code.
-    - `git checkout master`;
-    - update `neuro_extras/version.py`: `__version__ = "v20.10.15"` (note: no postfixes);
+    - update `neuro_extras/version.py`: set `__version__ = "20.10.15"`;
     - run `make changelog-draft` and verify changelog looks valid;
     - run `make changelog` - this will delete changelog items from `CHANGELOG.d`;
-    - `git add . && git commit -m "Release version v20.10.15"` and `push` directly to `origin/master`;
+    - `git add . && git commit -m "Release version 20.10.15"` and `push` directly to `origin/master`;
     - wait for green build in [Actions](https://github.com/neuro-inc/neuro-extras/actions);
 
-5. Submit a release on GitHub.
+2. Submit a release on GitHub.
     - go to [Releases](https://github.com/neuro-inc/neuro-extras/releases/), `Draft a new release`, tag: `v20.10.15` (note: no postfixes);
     - wait for green build in [Actions](https://github.com/neuro-inc/neuro-extras/actions);
+    - if the build failed, fix the errors and repeat from step 1. with version postfix: `20.10.15-1`.
     - verify that `pip install -U neuro-extras` does install `neuro-extras==20.10.15`
+
+
+# Alpha release
+
+To debug a release process without changing latest versions of package and image, you can issue an alpha release just postfixing the version with `a`:
+- `20.10.15a1`
+- `20.10.15a2`

--- a/neuro_extras/version.py
+++ b/neuro_extras/version.py
@@ -1,1 +1,3 @@
+# Note: version MUST be in format '20.10.23a6' because it defines the docker image
+# that we use, see tags in https://hub.docker.com/r/neuromation/neuro-extras/tags
 __version__ = "20.10.23a6"


### PR DESCRIPTION
Before, the release version was tested only against the docker version SHA of commit, so this testing was not real. And, as I discovered, version `v20.10.13a6` was broken (image was pushed with "v"), while the tests were green. I decided to separate flows into two:
1. `ci.yml` (only tests on commit against customly build image)
2. `cd.yml` (first release image and pypi, then run test suite against it)