### PR TITLE
Adapt Kaniko configuration (use v1.1.0 and /kaniko_context dir)

### DIFF
--- a/CHANGELOG.D/157.bugfix
+++ b/CHANGELOG.D/157.bugfix
@@ -1,0 +1,1 @@
+Speedup image build by Kaniko downgrade to v1.1.0 (COPY layers caching), replace /workspace context dir to /kaniko_context.

--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -967,9 +967,7 @@ class ImageBuilder:
             neuro_api.Volume(
                 docker_config_uri, "/kaniko/.docker/config.json", read_only=True
             ),
-            neuro_api.Volume(
-                context_uri, container_context_path, read_only=True
-            ),
+            neuro_api.Volume(context_uri, container_context_path, read_only=True),
         ]
 
         volumes.extend(default_volumes)

--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -1033,7 +1033,8 @@ class ImageBuilder:
             neuro_api.Volume(
                 docker_config_uri, "/kaniko/.docker/config.json", read_only=True
             ),
-            neuro_api.Volume(context_uri, container_context_path, read_only=True),
+            # context dir cannot be R/O if we want to mount secrets there
+            neuro_api.Volume(context_uri, container_context_path, read_only=False),
         ]
 
         volumes.extend(default_volumes)

--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -937,14 +937,16 @@ class ImageBuilder:
         )
         cache_repo = self.parse_image_ref(str(cache_image))
         cache_repo = re.sub(r":.*$", "", cache_repo)
+        container_context_path = "/kaniko_context"
         verbosity = "debug" if self._verbose else "info"
         args = [
-            f"--dockerfile={dockerfile_path}",
+            f"--dockerfile={container_context_path}/{dockerfile_path}",
             f"--destination={image_ref}",
             f"--cache=true",
             f"--cache-repo={cache_repo}",
             f"--snapshotMode=redo",
             f" --verbosity={verbosity}",
+            f" --context={container_context_path}",
         ]
 
         for arg in build_args:
@@ -965,8 +967,9 @@ class ImageBuilder:
             neuro_api.Volume(
                 docker_config_uri, "/kaniko/.docker/config.json", read_only=True
             ),
-            # TODO: try read only
-            neuro_api.Volume(context_uri, "/workspace"),
+            neuro_api.Volume(
+                context_uri, container_context_path, read_only=True
+            ),
         ]
 
         volumes.extend(default_volumes)

--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -982,7 +982,7 @@ class ImageBuilder:
         return neuro_api.Container(
             image=neuro_api.RemoteImage(
                 name="gcr.io/kaniko-project/executor",
-                tag="latest",
+                tag="v1.1.0",
             ),
             resources=resources,
             command=" ".join(args),

--- a/tests/e2e/test_main.py
+++ b/tests/e2e/test_main.py
@@ -555,7 +555,7 @@ def test_image_build_volume(cli_runner: CLIRunner, temp_random_secret: Secret) -
             "-f",
             str(dockerfile_path),
             "-v",
-            f"secret:{sec.name}:/workspace/secret.txt",
+            f"secret:{sec.name}:/kaniko_context/secret.txt",
             ".",
             img_uri_str,
         ]


### PR DESCRIPTION
Changes:
-  downgrade Kaniko version in order to return back the feature of COPY layer caching ([maybe](https://github.com/GoogleContainerTools/kaniko/issues/1489) this feature will be returned back later).
-  replace previously used `/workspace` context dir to `/kaniko_context`to avoid potential conflicts.