### PR TITLE
Image build via CLI, add build job tags support

### DIFF
--- a/CHANGELOG.D/205.bugfix
+++ b/CHANGELOG.D/205.bugfix
@@ -1,0 +1,1 @@
+Fix connection issues in image build jobs by relying on neuro-cli instead of neuro-sdk.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -165,21 +165,22 @@ Build Job container image remotely on cluster using Kaniko.
 **Usage:**
 
 ```bash
-neuro-extras image build [OPTIONS] PATH IMAGE_URI
+neuro-extras image build [OPTIONS] CONTEXT_PATH IMAGE_URI
 ```
 
 **Options:**
 
 | Name | Description |
 | :--- | :--- |
-| _-f, --file TEXT_ |  |
-| _--build-arg TEXT_ |  |
+| _-f, --file TEXT_ | Relative \(w.r.t. context\) path to the dockerfile. The dockerfile should be within the context directory.  \[default: Dockerfile\] |
+| _--build-arg VAR=VAL_ | Buid-time variables passed in ARG values, similarly to Docker. Could be used multiple times for multiple arguments. |
 | _-v, --volume MOUNT_ | Mounts directory from vault into container. Use multiple options to mount more than one volume. Use --volume=ALL to mount all accessible storage directories. |
 | _-e, --env VAR=VAL_ | Set environment variable in container Use multiple options to define more than one variable |
 | _-s, --preset PRESET_ | Predefined resource configuration \(to see available values, run `neuro config show`\) |
-| _-F, --force-overwrite_ | Build even if the destination image already exists. |
-| _--cache / --no-cache_ | Use kaniko cache while building image  \[default: True\] |
-| _--verbose BOOLEAN_ |  |
+| _-F, --force-overwrite_ | Overwrite if the destination image already exists.  \[default: False\] |
+| _--cache / --no-cache_ | Use Kaniko cache while building image.  \[default: True\] |
+| _--verbose BOOLEAN_ | If specified, run Kaniko with 'debug' verbosity, otherwise 'info' \(default\). |
+| _--build-tag VAR=VAL_ | Set tag\(s\) for image builder job. We will add tag 'kaniko-builds:{image-name}' authomatically. |
 | _--help_ | Show this message and exit. |
 
 #### neuro-extras image transfer

--- a/neuro_extras/image.py
+++ b/neuro_extras/image.py
@@ -195,7 +195,7 @@ async def _image_transfer(src_uri: str, dst_uri: str, force_overwrite: bool) -> 
             )
         )
         migration_job_tags = (
-            f"src-image:{str(src_image)}",
+            f"src-image:{src_image}",
             f"neuro-extras:image-transfer",
         )
         return await _build_image(

--- a/neuro_extras/image.py
+++ b/neuro_extras/image.py
@@ -196,8 +196,8 @@ async def _image_transfer(src_uri: str, dst_uri: str, force_overwrite: bool) -> 
             )
         )
         migration_job_tags = (
-            f"image-migrate-from={src_uri}",
-            f"image-migrate-to={dst_uri}",
+            f"src-img:{src_uri}",
+            f"dst-img:{dst_uri}",
         )
         return await _build_image(
             dockerfile_path=Path(dockerfile.name),

--- a/neuro_extras/image.py
+++ b/neuro_extras/image.py
@@ -183,7 +183,6 @@ async def _image_transfer(src_uri: str, dst_uri: str, force_overwrite: bool) -> 
     with tempfile.TemporaryDirectory() as tmpdir:
         async with get_neuro_client(cluster=src_cluster) as src_client:
             src_image = src_client.parse.remote_image(image=src_uri)
-            dst_image = src_client.parse.remote_image(image=dst_uri)
             src_client_config = src_client.config
 
         dockerfile = Path(f"{tmpdir}/Dockerfile")
@@ -196,10 +195,8 @@ async def _image_transfer(src_uri: str, dst_uri: str, force_overwrite: bool) -> 
             )
         )
         migration_job_tags = (
-            f"src-cluster:{src_image.cluster_name}",
-            f"dst-cluster:{dst_image.cluster_name}",
-            f"src-image:{src_image.owner}/{src_image.name}:{src_image.tag}",
-            f"dst-image:{dst_image.owner}/{dst_image.name}:{dst_image.tag}",
+            f"src-image:{str(src_image)}",
+            f"neuro-extras:image-transfer",
         )
         return await _build_image(
             dockerfile_path=Path(dockerfile.name),

--- a/neuro_extras/image.py
+++ b/neuro_extras/image.py
@@ -3,7 +3,7 @@ import sys
 import tempfile
 import textwrap
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple
 
 import click
 import neuro_sdk as neuro_api
@@ -13,7 +13,6 @@ from neuro_sdk.parsing_utils import _as_repo_str
 from neuro_sdk.url_utils import uri_from_cli
 
 from .cli import main
-from .common import _attach_job_stdout
 from .image_builder import ImageBuilder
 from .utils import get_neuro_client
 
@@ -50,8 +49,27 @@ def image_transfer(source: str, destination: str, force_overwrite: bool) -> None
 @image.command(
     "build", help="Build Job container image remotely on cluster using Kaniko."
 )
-@click.option("-f", "--file", default="Dockerfile")
-@click.option("--build-arg", multiple=True)
+@click.argument("path", metavar="CONTEXT_PATH")
+@click.argument("image_uri")
+@click.option(
+    "-f",
+    "--file",
+    default="Dockerfile",
+    show_default=True,
+    help=(
+        "Relative (w.r.t. context) path to the dockerfile. "
+        "The dockerfile should be within the context directory."
+    ),
+)
+@click.option(
+    "--build-arg",
+    multiple=True,
+    metavar="VAR=VAL",
+    help=(
+        "Buid-time variables passed in ARG values, similarly to Docker. "
+        "Could be used multiple times for multiple arguments."
+    ),
+)
 @click.option(
     "-v",
     "--volume",
@@ -86,35 +104,49 @@ def image_transfer(source: str, destination: str, force_overwrite: bool) -> None
     "-F",
     "--force-overwrite",
     default=False,
+    show_default=True,
     is_flag=True,
-    help="Build even if the destination image already exists.",
+    help="Overwrite if the destination image already exists.",
 )
 @click.option(
     "--cache/--no-cache",
     default=True,
     show_default=True,
-    help="Use kaniko cache while building image",
+    help="Use Kaniko cache while building image.",
 )
-@click.argument("path")
-@click.argument("image_uri")
-@click.option("--verbose", type=bool, default=False)
+@click.option(
+    "--verbose",
+    type=bool,
+    default=False,
+    help="If specified, run Kaniko with 'debug' verbosity, otherwise 'info' (default).",
+)
+@click.option(
+    "--build-tag",
+    multiple=True,
+    metavar="VAR=VAL",
+    help=(
+        "Set tag(s) for image builder job. "
+        "We will add tag 'kaniko-builds:{image-name}' authomatically."
+    ),
+)
 def image_build(
-    file: str,
-    build_arg: Sequence[str],
     path: str,
     image_uri: str,
-    volume: Sequence[str],
-    env: Sequence[str],
+    file: str,
+    build_arg: Tuple[str],
+    volume: Tuple[str],
+    env: Tuple[str],
     preset: str,
     force_overwrite: bool,
     cache: bool,
     verbose: bool,
+    build_tag: Tuple[str],
 ) -> None:
     try:
         sys.exit(
             run_async(
                 _build_image(
-                    dockerfile_path=file,
+                    dockerfile_path=Path(file),
                     context=path,
                     image_uri=image_uri,
                     use_cache=cache,
@@ -124,6 +156,7 @@ def image_build(
                     preset=preset,
                     force_overwrite=force_overwrite,
                     verbose=verbose,
+                    build_tags=build_tag,
                 )
             )
         )
@@ -162,27 +195,33 @@ async def _image_transfer(src_uri: str, dst_uri: str, force_overwrite: bool) -> 
                 """
             )
         )
+        migration_job_tags = (
+            f"image-migrate-from={src_uri}",
+            f"image-migrate-to={dst_uri}",
+        )
         return await _build_image(
-            dockerfile_path=dockerfile.name,
+            dockerfile_path=Path(dockerfile.name),
             context=tmpdir,
             image_uri=dst_uri,
             use_cache=True,
-            build_args=[],
-            volume=[],
-            env=[],
+            build_args=(),
+            volume=(),
+            env=(),
+            build_tags=migration_job_tags,
             force_overwrite=force_overwrite,
             other_client_configs=[src_client_config],
         )
 
 
 async def _build_image(
-    dockerfile_path: str,
+    dockerfile_path: Path,
     context: str,
     image_uri: str,
     use_cache: bool,
-    build_args: Sequence[str],
-    volume: Sequence[str],
-    env: Sequence[str],
+    build_args: Tuple[str, ...],
+    volume: Tuple[str, ...],
+    env: Tuple[str, ...],
+    build_tags: Tuple[str, ...],
     force_overwrite: bool,
     preset: Optional[str] = None,
     other_client_configs: Sequence[neuro_api.Config] = (),
@@ -190,9 +229,6 @@ async def _build_image(
 ) -> int:
     cluster = _get_cluster_from_uri(image_uri, scheme="image")
     async with get_neuro_client(cluster=cluster) as client:
-        if not preset:
-            preset = next(iter(client.config.presets.keys()))
-        job_preset = client.config.presets[preset]
         context_uri = uri_from_cli(
             context,
             client.username,
@@ -227,17 +263,17 @@ async def _build_image(
         builder = ImageBuilder(
             client, other_clients_configs=other_client_configs, verbose=verbose
         )
-        job = await builder.launch(
+        exit_code = await builder.build(
             dockerfile_path=dockerfile_path,
             context_uri=context_uri,
             image_uri_str=image_uri,
             use_cache=use_cache,
             build_args=build_args,
-            volume=volume,
-            env=env,
-            job_preset=job_preset,
+            volumes=volume,
+            envs=env,
+            job_preset=preset,
+            build_tags=build_tags,
         )
-        exit_code = await _attach_job_stdout(job, client, name="builder")
         if exit_code == EX_OK:
             logger.info(f"Successfully built {image_uri}")
             return EX_OK

--- a/neuro_extras/image_builder.py
+++ b/neuro_extras/image_builder.py
@@ -5,16 +5,20 @@ import logging
 import re
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Dict, Sequence
+from pathlib import Path
+from typing import Any, AsyncIterator, Dict, Optional, Sequence, Tuple
 
 import click
 import neuro_sdk as neuro_api
-from neuro_sdk import Preset, Resources
 from neuro_sdk.url_utils import normalize_storage_path_uri
 from yarl import URL
 
 
-logger = logging.getLogger(__name__)
+KANIKO_IMAGE_REF = "gcr.io/kaniko-project/executor"
+KANIKO_IMAGE_TAG = "v1.1.0"
+KANIKO_CONTEXT_PATH = "/kaniko_context"
+BUILDER_JOB_LIFESPAN = "4h"
+BUILDER_JOB_SHEDULE_TIMEOUT = "20m"
 
 
 @dataclass
@@ -48,6 +52,7 @@ class ImageBuilder:
         self._client = client
         self._other_clients_configs = list(other_clients_configs)
         self._verbose = verbose
+        self.logger = logging.getLogger(__name__)
 
     @property
     def _all_configs(self) -> Sequence[neuro_api.Config]:
@@ -84,19 +89,48 @@ class ImageBuilder:
 
         await self._client.storage.create(uri, _gen())
 
-    async def _create_builder_container(
+    def parse_image_ref(self, image_uri_str: str) -> str:
+        image = self._client.parse.remote_image(image_uri_str)
+        return re.sub(r"^http[s]?://", "", image.as_docker_url())
+
+    async def build(
         self,
-        *,
-        docker_config_uri: URL,
+        dockerfile_path: Path,
         context_uri: URL,
-        dockerfile_path: str,
-        image_ref: str,
-        use_cache: bool = True,
-        build_args: Sequence[str] = (),
-        volume: Sequence[str],
-        env: Sequence[str],
-        job_preset: Preset,
-    ) -> neuro_api.Container:
+        image_uri_str: str,
+        use_cache: bool,
+        build_args: Tuple[str, ...],
+        volumes: Tuple[str, ...],
+        envs: Tuple[str, ...],
+        job_preset: Optional[str],
+        build_tags: Tuple[str, ...],
+    ) -> int:
+        # TODO: check if Dockerfile exists
+        self.logger.info(f"Building the image {image_uri_str}")
+        self.logger.info(f"Using {context_uri} as the build context")
+
+        # upload (if needed) build context and platform registry auth info
+        build_uri = self._generate_build_uri()
+        await self._client.storage.mkdir(build_uri, parents=True)
+        if context_uri.scheme == "file":
+            local_context_uri, context_uri = context_uri, build_uri / "context"
+            self.logger.info(f"Uploading {local_context_uri} to {context_uri}")
+            subprocess = await asyncio.create_subprocess_exec(
+                "neuro",
+                "--disable-pypi-version-check",
+                "cp",
+                "--recursive",
+                str(local_context_uri),
+                str(context_uri),
+            )
+            return_code = await subprocess.wait()
+            if return_code != 0:
+                raise click.ClickException("Uploading build context failed!")
+
+        docker_config = await self.create_docker_config()
+        docker_config_uri = build_uri / ".docker.config.json"
+        self.logger.debug(f"Uploading {docker_config_uri}")
+        await self.save_docker_config(docker_config, docker_config_uri)
 
         cache_image = neuro_api.RemoteImage(
             name="layer-cache/cache",
@@ -105,116 +139,53 @@ class ImageBuilder:
             cluster_name=self._client.cluster_name,
         )
         cache_repo = self.parse_image_ref(str(cache_image))
-        cache_repo = re.sub(r":.*$", "", cache_repo)
-        container_context_path = "/kaniko_context"
-        verbosity = "debug" if self._verbose else "info"
-        cache = "true" if use_cache else "false"
-        args = [
-            f"--dockerfile={container_context_path}/{dockerfile_path}",
-            f"--destination={image_ref}",
-            f"--cache={cache}",
+        cache_repo = re.sub(r":.*$", "", cache_repo)  # drop tag
+
+        # mount build context and Kaniko auth info
+        volumes += (
+            f"{docker_config_uri}:/kaniko/.docker/config.json:ro",
+            # context dir cannot be R/O if we want to mount secrets there
+            f"{context_uri}:{KANIKO_CONTEXT_PATH}:rw",
+        )
+        build_tags += (f"kaniko-builds:{image_uri_str}",)
+        kaniko_args = [
+            f"--dockerfile={KANIKO_CONTEXT_PATH}/{dockerfile_path}",
+            f"--destination={self.parse_image_ref(image_uri_str)}",
+            f"--cache={'true' if use_cache else 'false'}",
             f"--cache-repo={cache_repo}",
             f"--snapshotMode=redo",
-            f" --verbosity={verbosity}",
-            f" --context={container_context_path}",
+            f"--verbosity={'debug' if self._verbose else 'info'}",
+            f"--context={KANIKO_CONTEXT_PATH}",
         ]
 
         for arg in build_args:
-            args.append(f" --build-arg {arg}")
-
-        env_parsed = self._client.parse.envs(env)
+            kaniko_args.append(f"--build-arg {arg}")
+        # env vars (which might be platform secrets too) are passed as build args
+        env_parsed = self._client.parse.envs(envs)
         for arg in list(env_parsed.env) + list(env_parsed.secret_env):
-            args.append(f"--build-arg {arg}")
+            kaniko_args.append(f"--build-arg {arg}")
 
-        vol = self._client.parse.volumes(volume)
-        volumes, secret_files, disk_volumes = (
-            list(vol.volumes),
-            list(vol.secret_files),
-            list(vol.disk_volumes),
-        )
-
-        default_volumes = [
-            neuro_api.Volume(
-                docker_config_uri, "/kaniko/.docker/config.json", read_only=True
-            ),
-            # context dir cannot be R/O if we want to mount secrets there
-            neuro_api.Volume(context_uri, container_context_path, read_only=False),
+        build_command = [
+            "neuro",
+            "--disable-pypi-version-check",
+            "job",
+            "run",
+            f"--life-span={BUILDER_JOB_LIFESPAN}",
+            f"--schedule-timeout={BUILDER_JOB_SHEDULE_TIMEOUT}",
         ]
+        if job_preset:
+            build_command.append(f"--preset={job_preset}")
+        for volume in volumes:
+            build_command.append(f"--volume={volume}")
+        for env in envs:
+            build_command.append(f"--env={env}")
+        for build_tag in build_tags:
+            build_command.append(f"--tag={build_tag}")
+        build_command.append(f"{KANIKO_IMAGE_REF}:{KANIKO_IMAGE_TAG}")
+        build_command.append(" ".join(kaniko_args))
 
-        volumes.extend(default_volumes)
-
-        resources = Resources(
-            memory_mb=job_preset.memory_mb,
-            cpu=job_preset.cpu,
-            gpu=job_preset.gpu,
-            gpu_model=job_preset.gpu_model,
-            tpu_type=job_preset.tpu_type,
-            tpu_software_version=job_preset.tpu_software_version,
-        )
-        return neuro_api.Container(
-            image=neuro_api.RemoteImage(
-                name="gcr.io/kaniko-project/executor",
-                tag="v1.1.0",
-            ),
-            resources=resources,
-            command=" ".join(args),
-            volumes=volumes,
-            disk_volumes=disk_volumes,
-            secret_files=secret_files,
-            env=env_parsed.env,
-            secret_env=env_parsed.secret_env,
-        )
-
-    def parse_image_ref(self, image_uri_str: str) -> str:
-        image = self._client.parse.remote_image(image_uri_str)
-        return re.sub(r"^http[s]?://", "", image.as_docker_url())
-
-    async def launch(
-        self,
-        dockerfile_path: str,
-        context_uri: URL,
-        image_uri_str: str,
-        use_cache: bool,
-        build_args: Sequence[str],
-        volume: Sequence[str],
-        env: Sequence[str],
-        job_preset: Preset,
-    ) -> neuro_api.JobDescription:
-        # TODO: check if Dockerfile exists
-
-        logging.info(f"Using {context_uri} as the build context")
-
-        build_uri = self._generate_build_uri()
-        await self._client.storage.mkdir(build_uri, parents=True, exist_ok=True)
-        if context_uri.scheme == "file":
-            local_context_uri, context_uri = context_uri, build_uri / "context"
-            logger.info(f"Uploading {local_context_uri} to {context_uri}")
-            subprocess = await asyncio.create_subprocess_exec(
-                "neuro", "cp", "--recursive", str(local_context_uri), str(context_uri)
-            )
-            return_code = await subprocess.wait()
-            if return_code != 0:
-                raise click.ClickException("Uploading build context failed!")
-
-        docker_config = await self.create_docker_config()
-        docker_config_uri = build_uri / ".docker.config.json"
-        logger.debug(f"Uploading {docker_config_uri}")
-        await self.save_docker_config(docker_config, docker_config_uri)
-
-        logger.info("Submitting a builder job")
-        image_ref = self.parse_image_ref(image_uri_str)
-        builder_container = await self._create_builder_container(
-            docker_config_uri=docker_config_uri,
-            context_uri=context_uri,
-            dockerfile_path=dockerfile_path,
-            image_ref=image_ref,
-            use_cache=use_cache,
-            build_args=build_args,
-            volume=volume,
-            env=env,
-            job_preset=job_preset,
-        )
-        # TODO: set proper tags
-        job = await self._client.jobs.run(builder_container, life_span=4 * 60 * 60)
-        logger.info(f"The builder job ID: {job.id}")
-        return job
+        self.logger.info("Submitting a builder job")
+        self.logger.info(build_command)
+        subprocess = await asyncio.create_subprocess_exec(*build_command)
+        # TODO: remove context after the build is finished?
+        return await subprocess.wait()

--- a/neuro_extras/image_builder.py
+++ b/neuro_extras/image_builder.py
@@ -185,7 +185,7 @@ class ImageBuilder:
         build_command.append(" ".join(kaniko_args))
 
         self.logger.info("Submitting a builder job")
-        self.logger.info(build_command)
+        self.logger.debug(build_command)
         subprocess = await asyncio.create_subprocess_exec(*build_command)
         # TODO: remove context after the build is finished?
         return await subprocess.wait()

--- a/neuro_extras/image_builder.py
+++ b/neuro_extras/image_builder.py
@@ -149,7 +149,7 @@ class ImageBuilder:
             f"{context_uri}:{KANIKO_CONTEXT_PATH}:rw",
         )
         dst_image = self._client.parse.remote_image(image_uri_str)
-        build_tags += (f"kaniko-builds-image:{str(dst_image)}",)
+        build_tags += (f"kaniko-builds-image:{dst_image}",)
         kaniko_args = [
             f"--dockerfile={KANIKO_CONTEXT_PATH}/{dockerfile_path}",
             f"--destination={self.parse_image_ref(image_uri_str)}",

--- a/neuro_extras/image_builder.py
+++ b/neuro_extras/image_builder.py
@@ -149,9 +149,7 @@ class ImageBuilder:
             f"{context_uri}:{KANIKO_CONTEXT_PATH}:rw",
         )
         dst_image = self._client.parse.remote_image(image_uri_str)
-        build_tags += (
-            f"kaniko-builds-image:{dst_image.owner}/{dst_image.name}:{dst_image.tag}",
-        )
+        build_tags += (f"kaniko-builds-image:{str(dst_image)}",)
         kaniko_args = [
             f"--dockerfile={KANIKO_CONTEXT_PATH}/{dockerfile_path}",
             f"--destination={self.parse_image_ref(image_uri_str)}",

--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -33,12 +33,13 @@ def init_aliases() -> None:
         "options": [
             "-f, --file=PATH  path to the Dockerfile within CONTEXT",
             "--build-arg=LIST  build arguments for Docker",
+            "--build-tag=LIST  tag(s) for image builder job.",
             "-e, --env=LIST  environment variables for container",
             "-v, --volume=LIST  list of volumes for container",
             "-s, --preset=STR  specify  preset for builder container",
             "-F, --force-overwrite  enforce destination image overwrite",
         ],
-        "args": "CONTEXT IMAGE_URI",
+        "args": "CONTEXT_PATH IMAGE_URI",
         "help": (
             "Build docker image on the platform. "
             "Hit `neuro-extras image build --help` for more info."

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 click==7.1.2
 dataclasses==0.7; python_version<"3.7"
-neuro-cli==21.1.13
+neuro-cli==21.2.19
 pyyaml==5.3.1
 toml==0.10.2


### PR DESCRIPTION
Changes:
- Major:
1. Execute image build (and transfer) jobs via neuro-cli
2. Use presets for image build, instead of bare resource claims
3. Add support of image build job tags, add default tags for (1) image build (kaniko:{target-image}) and (2) image transfer (kaniko:{src-img}, kaniko:{dst-img}).
- Minor:
1. Bump schedule-timeout of builder job to 20mins
2. Suppress notifications related to outdated neuro-cli in image build actions (context copying, job execution).

Fixes #205, #165 
Part of #206

Concerns: 
- should we [remove build context from storage](https://github.com/neuro-inc/neuro-extras/pull/207/commits/821bcee8d1be942c484f88af186dd735efe1315b#diff-444d5213bba3111591963556061c5954972fae426b13b369ee2f9d4ef99e11e2R190) after the image was built?
- should I add tests for tags?