### PR TITLE
Fix kaniko --dockerfile options if Path is windows path

### DIFF
--- a/neuro_extras/image_builder.py
+++ b/neuro_extras/image_builder.py
@@ -260,7 +260,7 @@ class RemoteImageBuilder(ImageBuilder):
         dst_image = self._client.parse.remote_image(image_uri_str)
         build_tags += (f"kaniko-builds-image:{dst_image}",)
         kaniko_args = [
-            f"--dockerfile={KANIKO_CONTEXT_PATH}/{dockerfile_path}",
+            f"--dockerfile={KANIKO_CONTEXT_PATH}/{dockerfile_path.as_posix()}",
             f"--destination={self.parse_image_ref(image_uri_str)}",
             f"--cache={'true' if use_cache else 'false'}",
             # f"--cache-copy-layers", # TODO: since kaniko 1.3 does not support it


### PR DESCRIPTION
On windows, the relative docker file path stored in **Path** variable produces `\` slashes when transformed to string. But, as kaniko will run in docker, we have to transform POSIX format.