### PR TITLE
Handle spaces in file paths and preserve symlinks

### DIFF
--- a/apolo_extras/data/__init__.py
+++ b/apolo_extras/data/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import shlex
 from pathlib import Path
 from typing import Optional, Sequence
 
@@ -209,12 +210,25 @@ async def _run_copy_container(
         f"{dst_uri_str}:/storage:rw",
         "-e",
         f"APOLO_CLUSTER={src_cluster}",  # inside the job, switch apolo to 'src_cluster'
-        "--life-span 10d",
+        "--life-span",
+        "10d",
         APOLO_EXTRAS_IMAGE,
         "--",
-        f"apolo --show-traceback cp --progress -r -u -T {src_uri_str} /storage",
+        shlex.join(
+            [
+                "apolo",
+                "--show-traceback",
+                "cp",
+                "--progress",
+                "-r",
+                "-u",
+                "-T",
+                src_uri_str,
+                "/storage",
+            ]
+        ),
     ]
-    cmd = " ".join(args)
+    cmd = shlex.join(args)
     click.echo(f"Running '{cmd}'")
     subprocess = await asyncio.create_subprocess_shell(cmd)
     returncode = await subprocess.wait()

--- a/apolo_extras/data/archive.py
+++ b/apolo_extras/data/archive.py
@@ -45,9 +45,9 @@ class TarManager(ArchiveManager, CLIRunner):
         subcommand = mapping[destination.archive_type]
         args = [
             subcommand,
-            str(destination),
+            str(destination.as_local_path()),
             # f"--exclude={destination.filename}",
-            str(source),
+            str(source.as_local_path()),
         ]
         await self.run_command(command=command, args=args)
         return destination
@@ -68,8 +68,13 @@ class TarManager(ArchiveManager, CLIRunner):
             ArchiveType.TAR_PLAIN: "xvf",
         }
         subcommand = mapping[source.archive_type]
-        args = [subcommand, source.as_str(), f"-C", destination.as_str()]
-        destination.as_path().mkdir(exist_ok=True, parents=True)
+        args = [
+            subcommand,
+            str(source.as_local_path()),
+            "-C",
+            str(destination.as_local_path()),
+        ]
+        destination.as_local_path().mkdir(exist_ok=True, parents=True)
         await self.run_command(command=command, args=args)
         return destination
 
@@ -92,12 +97,14 @@ class GzipManager(ArchiveManager, CLIRunner):
                 "gzip does not support folder compression, "
                 "use .tar.gz extension instead."
             )
-        args = ["-rkvf", source.as_str()]
+        args = ["-rkvf", str(source.as_local_path())]
         await self.run_command(command=command, args=args)
         # gzip does not support setting destination
-        temp_destination = source.as_str() + ".gz"
+        temp_destination = str(source.as_local_path()) + ".gz"
         # TODO: add support for non-unix OS
-        await self.run_command("mv", ["-v", temp_destination, destination.as_str()])
+        await self.run_command(
+            "mv", ["-v", temp_destination, str(destination.as_local_path())]
+        )
         return destination
 
     async def extract(self, source: Resource, destination: Resource) -> Resource:
@@ -110,12 +117,14 @@ class GzipManager(ArchiveManager, CLIRunner):
                 f"Supported types: "
                 f"{ArchiveType.get_extensions_for_type(ArchiveType.GZ)}"
             )
-        args = ["--keep", source.as_str()]
+        args = ["--keep", str(source.as_local_path())]
         await self.run_command(command=command, args=args)
         temp_destination = str(
-            source.as_path().with_suffix("")
+            source.as_local_path().with_suffix("")
         )  # gzip extracts inplace
-        await self.run_command("mv", ["-v", temp_destination, destination.as_str()])
+        await self.run_command(
+            "mv", ["-v", temp_destination, str(destination.as_local_path())]
+        )
         return destination
 
 
@@ -133,7 +142,11 @@ class ZipManager(ArchiveManager, CLIRunner):
                 f"{ArchiveType.get_extensions_for_type(ArchiveType.ZIP)}"
             )
         # check if works as expected
-        args = ["-rv", destination.as_str(), source.as_str()]
+        args = [
+            "-rv",
+            str(destination.as_local_path()),
+            str(source.as_local_path()),
+        ]
         await self.run_command(command=command, args=args)
         return destination
 
@@ -147,8 +160,13 @@ class ZipManager(ArchiveManager, CLIRunner):
                 f"Supported types: "
                 f"{ArchiveType.get_extensions_for_type(ArchiveType.ZIP)}"
             )
-        args = ["-o", source.as_str(), "-d", destination.as_str()]
-        destination.as_path().mkdir(exist_ok=True, parents=True)
+        args = [
+            "-o",
+            str(source.as_local_path()),
+            "-d",
+            str(destination.as_local_path()),
+        ]
+        destination.as_local_path().mkdir(exist_ok=True, parents=True)
         await self.run_command(command=command, args=args)
         return destination
 
@@ -173,7 +191,7 @@ def _get_archive_manager(archive: Resource) -> ArchiveManager:
 async def copy(source: Resource, destination: Resource) -> Resource:
     """Copy source into destination"""
     command = "cp"
-    args = [source.as_str(), destination.as_str()]
+    args = [str(source.as_local_path()), str(destination.as_local_path())]
     runner = CLIRunner()
     await runner.run_command(command=command, args=args)
     return destination

--- a/apolo_extras/data/common.py
+++ b/apolo_extras/data/common.py
@@ -291,6 +291,11 @@ class Resource:
     def as_path(self) -> Path:
         return Path(self.url.path)
 
+    def as_local_path(self) -> Path:
+        if self.data_url_type != DataUrlType.LOCAL_FS:
+            raise ValueError(f"Resource {self} is not a local filesystem path")
+        return self.as_path()
+
     def as_str(self) -> str:
         return str(self.url)
 
@@ -337,7 +342,7 @@ class Resource:
 
 def ensure_folder_exists(local_resource: Resource) -> None:
     """Ensure the folder (in case of the file resource - parent folder) exists"""
-    folder_name, _ = os.path.split(local_resource.as_str())
+    folder_name, _ = os.path.split(str(local_resource.as_local_path()))
     logger.info(f"Creating folder for {folder_name}")
     Path(folder_name).mkdir(exist_ok=True, parents=True)
 

--- a/apolo_extras/data/fs.py
+++ b/apolo_extras/data/fs.py
@@ -19,17 +19,31 @@ class LocalFSCopier(Copier, CLIRunner):
 
     async def perform_copy(self) -> Resource:
         """Perform copy through running rclone and return the url to destinaton"""
-        destination_path = Path(self.destination.url.path)
+        destination_path = self.destination.as_local_path()
         destination_parent_folder, _ = os.path.split(destination_path)
         Path(destination_parent_folder).mkdir(exist_ok=True, parents=True)
         command = "rclone"
-        args = [
-            "copyto",  # TODO: investigate usage of 'sync' for potential speedup.
-            "--checkers=16",  # https://rclone.org/docs/#checkers-n , default is 8
-            "--transfers=8",  # https://rclone.org/docs/#transfers-n , default is 4.
-            "--verbose=1",  # default is 0, set 2 for debug
-            self.source.as_str(),
-            self.destination.as_str(),
-        ]
+        source_path = self.source.as_local_path()
+        if source_path.is_dir():
+            # Preserve symlinks when copying directory trees from mounted storage.
+            args = [
+                "copy",
+                "--links",
+                "--checkers=16",  # https://rclone.org/docs/#checkers-n , default is 8
+                "--transfers=8",  # https://rclone.org/docs/#transfers-n , default is 4.
+                "--verbose=1",  # default is 0, set 2 for debug
+                str(self.source.as_local_path()),
+                str(self.destination.as_local_path()),
+            ]
+        else:
+            args = [
+                "copyto",  # TODO: investigate usage of 'sync' for potential speedup.
+                "--links",
+                "--checkers=16",  # https://rclone.org/docs/#checkers-n , default is 8
+                "--transfers=8",  # https://rclone.org/docs/#transfers-n , default is 4.
+                "--verbose=1",  # default is 0, set 2 for debug
+                str(self.source.as_local_path()),
+                str(self.destination.as_local_path()),
+            ]
         await self.run_command(command=command, args=args)
         return self.destination

--- a/apolo_extras/data/remote.py
+++ b/apolo_extras/data/remote.py
@@ -1,6 +1,7 @@
 """Module for copying files by running neu.ro jobs"""
 
 import logging
+import shlex
 from dataclasses import dataclass, replace
 from typing import List, Mapping, Optional, Tuple
 
@@ -251,4 +252,4 @@ def _build_data_copy_command(
     if extract:
         flags.append("-x")
     full_command = command_prefix + flags + args
-    return " ".join(full_command)
+    return shlex.join(full_command)

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,6 +113,8 @@ apolo-extras config save-registry-auth ${HOME}/.docker/config.json --cluster def
 ### Data Transfer Between Projects
 The apolo-extras data transfer command facilitates data movement between different internal storage locations. This is not supported with regular Apolo CLI apolo cp.
 
+Generated copy commands now quote paths safely, so filenames with spaces are handled correctly. Local filesystem directory copies also preserve symlinks instead of failing on symlinked entries.
+
 Between directories in the same project:
 ```bash
 # Copy data between directories on the same project

--- a/tests/unit/data/test_archive_paths.py
+++ b/tests/unit/data/test_archive_paths.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from apolo_extras.data.archive import copy
+from apolo_extras.data.common import Resource
+from apolo_extras.utils import CLIRunner
+
+
+@pytest.mark.asyncio
+async def test_archive_copy_uses_raw_local_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source tree" / "file name.txt"
+    source.parent.mkdir()
+    source.write_text("payload")
+    destination = tmp_path / "destination tree" / "copied name.txt"
+
+    run_command = AsyncMock(return_value=None)
+    monkeypatch.setattr(CLIRunner, "run_command", run_command)
+
+    await copy(Resource.from_path(source), Resource.from_path(destination))
+
+    run_command.assert_awaited_once()
+    assert run_command.await_args is not None
+    kwargs = run_command.await_args.kwargs
+    assert kwargs["command"] == "cp"
+    assert kwargs["args"] == [str(source), str(destination)]

--- a/tests/unit/data/test_copy_commands.py
+++ b/tests/unit/data/test_copy_commands.py
@@ -1,0 +1,54 @@
+import asyncio
+
+import pytest
+
+from apolo_extras.data import _run_copy_container
+from apolo_extras.data.remote import _build_data_copy_command
+
+
+def test_build_data_copy_command_quotes_spaces() -> None:
+    command = _build_data_copy_command(
+        source="storage://cluster/org/project/log_DateTime_2025-05-21 13:22:16",
+        destination="/tmp/destination folder",
+        extract=False,
+        compress=False,
+    )
+
+    assert command.startswith("apolo-extras -v data cp ")
+    assert "'storage://cluster/org/project/log_DateTime_2025-05-21 13:22:16'" in command
+    assert "'/tmp/destination folder'" in command
+
+
+@pytest.mark.asyncio
+async def test_run_copy_container_quotes_shell_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    class DummyProcess:
+        async def wait(self) -> int:
+            return 0
+
+    async def fake_create_subprocess_shell(cmd: str) -> DummyProcess:
+        captured["cmd"] = cmd
+        return DummyProcess()
+
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_shell", fake_create_subprocess_shell
+    )
+
+    await _run_copy_container(
+        src_cluster="imdc",
+        src_uri_str="storage://imdc/amv/amv-cv/log_DateTime_2025-05-21 13:22:16",
+        dst_uri_str="storage://apolo-main/amv/amv-cv/output folder",
+    )
+
+    assert "APOLO_CLUSTER=imdc" in captured["cmd"]
+    assert (
+        "'storage://imdc/amv/amv-cv/log_DateTime_2025-05-21 13:22:16'"
+        in captured["cmd"]
+    )
+    assert (
+        "'storage://apolo-main/amv/amv-cv/output folder:/storage:rw'" in captured["cmd"]
+    )
+    assert "'apolo --show-traceback cp --progress -r -u -T" in captured["cmd"]

--- a/tests/unit/data/test_local_fs_copier.py
+++ b/tests/unit/data/test_local_fs_copier.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from apolo_extras.data.common import Resource
+from apolo_extras.data.fs import LocalFSCopier
+
+
+@pytest.mark.asyncio
+async def test_local_fs_copier_uses_copy_for_directory_trees(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_dir = tmp_path / "source tree"
+    source_dir.mkdir()
+    (source_dir / "real.txt").write_text("payload")
+    symlink = source_dir / "linked.txt"
+    symlink.symlink_to(source_dir / "real.txt")
+    destination_dir = tmp_path / "destination tree"
+
+    copier = LocalFSCopier(
+        source=Resource.from_path(source_dir),
+        destination=Resource.from_path(destination_dir),
+    )
+    run_command = AsyncMock(return_value=None)
+    monkeypatch.setattr(copier, "run_command", run_command)
+
+    await copier.perform_copy()
+
+    run_command.assert_awaited_once()
+    assert run_command.await_args is not None
+    kwargs = run_command.await_args.kwargs
+    assert kwargs["command"] == "rclone"
+    assert kwargs["args"][0] == "copy"
+    assert "--links" in kwargs["args"]
+    assert kwargs["args"][-2:] == [
+        str(source_dir),
+        str(destination_dir),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_local_fs_copier_uses_copyto_for_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_file = tmp_path / "source file.txt"
+    source_file.write_text("payload")
+    destination_file = tmp_path / "destination file.txt"
+
+    copier = LocalFSCopier(
+        source=Resource.from_path(source_file),
+        destination=Resource.from_path(destination_file),
+    )
+    run_command = AsyncMock(return_value=None)
+    monkeypatch.setattr(copier, "run_command", run_command)
+
+    await copier.perform_copy()
+
+    run_command.assert_awaited_once()
+    assert run_command.await_args is not None
+    kwargs = run_command.await_args.kwargs
+    assert kwargs["command"] == "rclone"
+    assert kwargs["args"][0] == "copyto"
+    assert "--links" in kwargs["args"]
+    assert kwargs["args"][-2:] == [
+        str(source_file),
+        str(destination_file),
+    ]


### PR DESCRIPTION
This pull request improves the reliability and safety of file and directory copying in the codebase, especially for paths with spaces and for directory trees containing symlinks. The main changes ensure all shell commands use proper quoting, local filesystem paths are handled correctly, and symlinks are preserved during local directory copies. Comprehensive tests have been added to verify these behaviors.