### PR TITLE
build(deps): bump setuptools from 80.9.0 to 83.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,5 +2,5 @@ apolo-cli==25.9.1
 apolo-sdk==25.9.1
 click==8.3.0
 pyyaml==6.0.3
-setuptools==80.9.0
+setuptools==83.0.0
 toml==0.10.2


### PR DESCRIPTION
Bumps `setuptools` from 80.9.0 to 83.0.0 to resolve the open Dependabot vulnerability alert (fixed version `>= 83.0.0`).

Context: this is tracked in Sprinto vulnerability management. The existing Dependabot version-update PR #767 only bumps to 80.10.2, which is below the fixed version and does **not** clear the alert — this PR supersedes it (please close #767 once this merges).

- Alert: setuptools vulnerable in `< 83.0.0`, first patched `83.0.0`
- File: `requirements/base.txt`